### PR TITLE
Removed public-block in object

### DIFF
--- a/vm/instruction.bal
+++ b/vm/instruction.bal
@@ -1,9 +1,7 @@
 public type Instruction object {
 
-    public {
-        OPCODE opcode;
-        int[] operands;
-    }
+    public OPCODE opcode;
+    public int[] operands;
 
     // Operands are defined as rest parameter which can take 0 or more arguments.
     public new(opcode, int... args) {


### PR DESCRIPTION
With Ballerina version 0.982.0 (latest version, running under Windows 7 x64) it is not possible to declare OPCODE opcode and int[] operands inside a public-block (e.g. public { ... }).

With these changes the code compiles and executes smoothly.